### PR TITLE
Undo workaround for ci.maven issue #359

### DIFF
--- a/src/it/test15Explicit/pom.xml
+++ b/src/it/test15Explicit/pom.xml
@@ -100,6 +100,15 @@
                 <groupId>boost.project</groupId>
                 <artifactId>boost-maven-plugin</artifactId>
                 <version>1.0-SNAPSHOT</version>
+                <!-- Test configurable runtime artifact -->
+                <configuration>
+                    <runtimeArtifact>
+                        <groupId>com.ibm.websphere.appserver.runtime</groupId>
+                        <artifactId>wlp-webProfile7</artifactId>
+                        <version>18.0.0.2</version>
+                        <type>zip</type>
+                    </runtimeArtifact>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
The workaround for [ci.maven issue #359](https://github.com/WASdev/ci.maven/issues/359) in 
2636d0ab19832ab104c339df12d7a8c28bd1057f has us only using OL runtimes.

This PR re-enables the WLP artifact in one IT.

Note this will fail CI until 18003.