### PR TITLE
Use Spring Boot server.port as Liberty defaultHttpEndpoint 

### DIFF
--- a/src/it/test20Implicit/pom.xml
+++ b/src/it/test20Implicit/pom.xml
@@ -90,8 +90,8 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>boost.project</groupId>
+	       <plugin>
+            	<groupId>boost.project</groupId>
 				<artifactId>boost-maven-plugin</artifactId>
 				<version>1.0-SNAPSHOT</version>
 				<executions>

--- a/src/main/java/boost/project/utils/ConfigConstants.java
+++ b/src/main/java/boost/project/utils/ConfigConstants.java
@@ -1,4 +1,4 @@
-package boost.project;
+package boost.project.utils;
 
 public interface ConfigConstants {
 	public String FEATURE = "feature";

--- a/src/main/java/boost/project/utils/LibertyServerConfigGenerator.java
+++ b/src/main/java/boost/project/utils/LibertyServerConfigGenerator.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package boost.project;
+package boost.project.utils;
 
 import java.io.File;
 import java.util.HashSet;
@@ -28,12 +28,14 @@ import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import static boost.project.utils.ConfigConstants.*;
+
 
 /**
  * Create a Liberty server.xml
  *
  */
-public class LibertyServerConfigGenerator implements ConfigConstants {
+public class LibertyServerConfigGenerator {
     
 	Document doc;
 	Element featureManager;

--- a/src/main/java/boost/project/utils/SpringBootProjectUtils.java
+++ b/src/main/java/boost/project/utils/SpringBootProjectUtils.java
@@ -1,0 +1,138 @@
+package boost.project.utils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import static boost.project.utils.ConfigConstants.*;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+
+public class SpringBootProjectUtils {
+
+    private static final String SERVER_PORT = "server.port";
+    private static final String DEFAULT_SERVER_PORT = "8080";
+
+    private static final String APPLICATION_PROPERTIES_FILE = "application.properties";
+
+    public static Properties getSpringBootServerProperties(String buildDir) throws IOException {
+
+        Properties serverProperties = new Properties();
+
+        Properties allProperties = new Properties();
+        InputStream input = null;
+
+        try {
+
+            File appProperties = new File(buildDir + "/classes", APPLICATION_PROPERTIES_FILE);
+
+            if (appProperties.exists()) {
+                input = new FileInputStream(appProperties.getAbsolutePath());
+                allProperties.load(input);
+            }
+
+        } finally {
+            if (input != null) {
+                input.close();
+            }
+        }
+
+        String serverPort = (String) allProperties.getOrDefault(SERVER_PORT, DEFAULT_SERVER_PORT);
+        serverProperties.setProperty(SERVER_PORT, serverPort);
+
+        return serverProperties;
+    }
+
+    public static List<String> getLibertyFeaturesNeeded(MavenProject mavenProject, Log consoleLogger) {
+
+        List<String> featuresToAdd = new ArrayList<String>();
+
+        String springBootVersion = findSpringBootVersion(mavenProject);
+
+        if (springBootVersion != null) {
+
+            String springBootFeature = null;
+
+            if (springBootVersion.startsWith("1.")) {
+                springBootFeature = SPRING_BOOT_15;
+            } else if (springBootVersion.startsWith("2.")) {
+                springBootFeature = SPRING_BOOT_20;
+            } else {
+                // log error for unsupported version
+                consoleLogger
+                .error("No supporting feature available in Open Liberty for org.springframework.boot dependency with version "
+                        + springBootVersion);
+            }
+
+            if (springBootFeature != null) {
+                consoleLogger
+                .info("Adding the " + springBootFeature + " feature to the Open Liberty server configuration.");
+                featuresToAdd.add(springBootFeature);
+            }
+
+        } else {
+            consoleLogger.info(
+                    "The springBoot feature was not added to the Open Liberty server because no spring-boot-starter dependencies were found.");
+        }
+
+        // Add any other Liberty features needed depending on the spring boot
+        // starters defined
+        List<String> springBootStarters = getSpringBootStarters(mavenProject);
+
+        for (String springBootStarter : springBootStarters) {
+
+            if (springBootStarter.equals("spring-boot-starter-web")) {
+                // Add the servlet-4.0 feature
+                featuresToAdd.add(SERVLET_40);
+            }
+
+            // TODO: Add more dependency mappings if needed.
+        }
+
+        return featuresToAdd;
+    }
+
+    /**
+     * Detect spring boot version dependency
+     */
+    private static String findSpringBootVersion(MavenProject project) {
+        String version = null;
+
+        Set<Artifact> artifacts = project.getArtifacts();
+        for (Artifact art : artifacts) {
+            if ("org.springframework.boot".equals(art.getGroupId()) && "spring-boot".equals(art.getArtifactId())) {
+                version = art.getVersion();
+                break;
+            }
+        }
+
+        return version;
+    }
+
+    /**
+     * Get all dependencies with "spring-boot-starter-*" as the artifactId.
+     * These dependencies will be used to determine which additional Liberty
+     * features need to be enabled.
+     * 
+     */
+    private static List<String> getSpringBootStarters(MavenProject project) {
+
+        List<String> springBootStarters = new ArrayList<String>();
+
+        Set<Artifact> artifacts = project.getArtifacts();
+        for (Artifact art : artifacts) {
+            if (art.getArtifactId().contains("spring-boot-starter")) {
+                springBootStarters.add(art.getArtifactId());
+            }
+        }
+
+        return springBootStarters;
+    }
+}

--- a/src/test/java/boost/project/utils/LibertyServerConfigGeneratorTest.java
+++ b/src/test/java/boost/project/utils/LibertyServerConfigGeneratorTest.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package boost.project;
+package boost.project.utils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -26,7 +26,10 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.w3c.dom.Element;
 
-public class LibertyServerConfigGeneratorTest implements ConfigConstants{
+import static boost.project.utils.ConfigConstants.*;
+import boost.project.utils.LibertyServerConfigGenerator;
+
+public class LibertyServerConfigGeneratorTest {
 
     @Rule
     public TemporaryFolder outputDir = new TemporaryFolder();
@@ -58,10 +61,10 @@ public class LibertyServerConfigGeneratorTest implements ConfigConstants{
     public void testZeroFeaturesInDefaultServerConfig() throws ParserConfigurationException, TransformerException, IOException {
         LibertyServerConfigGenerator g = new LibertyServerConfigGenerator();
         Element serverRoot = g.doc.getDocumentElement();
-        List<Element> featureMgrList = getDirectChildrenByTag(serverRoot, LibertyServerConfigGenerator.FEATURE_MANAGER);
+        List<Element> featureMgrList = getDirectChildrenByTag(serverRoot, FEATURE_MANAGER);
         assertEquals("Didn't find one and only one featureMgr", 1, featureMgrList.size());
         Element featureMgr = featureMgrList.get(0);
-        List<Element> featureList = getDirectChildrenByTag(featureMgr, LibertyServerConfigGenerator.FEATURE);
+        List<Element> featureList = getDirectChildrenByTag(featureMgr, FEATURE);
         assertEquals("Didn't find empty list of features", 0, featureList.size());
     }
 


### PR DESCRIPTION
Boost will lookup the server.port from an application.properties file (or use default 8080) and set a corresponding "server.port" property with that value in the Liberty server's bootstrap.properties. This allows the Liberty server to startup with the application server.port as the defaultHttpEndpoint httpPort. 

Also refactored some of the Spring Boot project specific methods into a SpringBootProjectUtils class. 