### PR TITLE
Rename BOM module; move boost-maven-plugin dependencies to this modul…

### DIFF
--- a/boost-bom/pom.xml
+++ b/boost-bom/pom.xml
@@ -4,15 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-	<parent>
+    <parent>
         <groupId>io.openliberty.boost</groupId>
-		<artifactId>boost-maven-parent</artifactId>
-		<version>0.1-SNAPSHOT</version>
+        <artifactId>boost-maven-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
     </parent>
-	
+    
     <groupId>io.openliberty.boost</groupId>
-    <artifactId>liberty-boost-bom</artifactId>
-    <version>0.1-SNAPSHOT</version>	
+    <artifactId>boost-bom</artifactId>
+    <version>0.1-SNAPSHOT</version>    
     <packaging>pom</packaging>
 
     <description>Liberty Boost EE Feature Bom</description>

--- a/boost-maven-plugin/pom.xml
+++ b/boost-maven-plugin/pom.xml
@@ -7,10 +7,10 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-	<parent>
+    <parent>
         <groupId>io.openliberty.boost</groupId>
-		<artifactId>boost-maven-parent</artifactId>
-		<version>0.1-SNAPSHOT</version>
+        <artifactId>boost-maven-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
     </parent>
     
     <artifactId>boost-maven-plugin</artifactId>
@@ -24,22 +24,29 @@
     </properties>
 
     <dependencies>
-		<dependency>
-			<groupId>io.openliberty.boost</groupId>
-			<artifactId>liberty-boost-bom</artifactId>
-			<version>0.1-SNAPSHOT</version>
-			<type>pom</type>
-		</dependency>
+
+        <!-- Boost dependencies -->
+
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>20.0</version>
+            <groupId>io.openliberty.boost</groupId>
+            <artifactId>boost-bom</artifactId>
+            <version>0.1-SNAPSHOT</version>
+            <type>pom</type>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.openliberty.boost</groupId>
             <artifactId>boost-common</artifactId>
             <version>0.1-SNAPSHOT</version>
-        </dependency>	
+        </dependency>    
+
+        <!-- Other dependencies -->
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>20.0</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
@@ -55,17 +62,38 @@
             <groupId>org.twdata.maven</groupId>
             <artifactId>mojo-executor</artifactId>
             <version>2.3.0</version>
-        </dependency>	
-		<dependency>
-		    <groupId>com.spotify</groupId>
-		    <artifactId>docker-client</artifactId>
-		    <version>8.11.7</version>
-		</dependency>
-		<dependency>
-		    <groupId>com.google.code.gson</groupId>
-		    <artifactId>gson</artifactId>
-		    <version>2.8.0</version>
-		</dependency>
+        </dependency>    
+        <dependency>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-client</artifactId>
+            <version>8.11.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+
+        <dependency>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>plugin-support</artifactId>
+                <version>1.0-alpha-1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.maven</groupId>
+                        <artifactId>maven-project</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.maven</groupId>
+                        <artifactId>maven-artifact</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.maven</groupId>
+                        <artifactId>maven-plugin-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+ 
     </dependencies>
 
     <profiles>
@@ -118,4 +146,5 @@
             </plugin>    
         </plugins>
     </build>
+
 </project>

--- a/boost-maven-plugin/src/it/test-jaxrs-2.0/pom.xml
+++ b/boost-maven-plugin/src/it/test-jaxrs-2.0/pom.xml
@@ -33,7 +33,7 @@
 		<dependencies>
 			<dependency>
 				<groupId>io.openliberty.boost</groupId>
-				<artifactId>liberty-boost-bom</artifactId>
+				<artifactId>boost-bom</artifactId>
 				<version>0.1-SNAPSHOT</version>
 				<scope>import</scope>
 				<type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -10,15 +10,15 @@
     <groupId>io.openliberty.boost</groupId>
     <artifactId>boost-maven-parent</artifactId>
     <version>0.1-SNAPSHOT</version>
-	<packaging>pom</packaging>
+    <packaging>pom</packaging>
     
-	<name>boost-maven-plugin Parent</name>
-	
-	<modules>
-		<module>liberty-boost-bom</module>
-		<module>boost-maven-plugin</module>
-	</modules>
-	
+    <name>boost-maven-plugin Parent</name>
+    
+    <modules>
+        <module>boost-bom</module>
+        <module>boost-maven-plugin</module>
+    </modules>
+    
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -26,52 +26,15 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-api</artifactId>
-            <version>2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugin-tools</groupId>
-            <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.4</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.twdata.maven</groupId>
-            <artifactId>mojo-executor</artifactId>
-            <version>2.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>plugin-support</artifactId>
-            <version>1.0-alpha-1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.maven</groupId>
-                    <artifactId>maven-project</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.maven</groupId>
-                    <artifactId>maven-artifact</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.maven</groupId>
-                    <artifactId>maven-plugin-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-           <groupId>io.openliberty.boost</groupId>
-           <artifactId>boost-common</artifactId>
-           <version>0.1-SNAPSHOT</version>
-        </dependency>
-    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 </project>


### PR DESCRIPTION
I'm not saying this accomplishes much but a small amount of dependency hygeine.

It didn't seem like there was any value though of having dependencies in the parent POM rather than the boost-maven-plugin POM.

It's possible perhaps at some point we'll want to share some dependency/pluginMgmt across the BOM, BMP, and test modules.. but until then the parent should be minimal.

Also renamed **liberty-boost-bom** to **boost-bom**.