### PR TITLE
Fix bugs with docker-build and spring-boot-maven-plugin classifier

### DIFF
--- a/boost-maven-plugin/pom.xml
+++ b/boost-maven-plugin/pom.xml
@@ -3,7 +3,8 @@
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 
     and is available at http://www.eclipse.org/legal/epl-v10.html Contributors: 
     IBM Corporation - initial API and implementation -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -11,7 +12,7 @@
         <artifactId>boost-maven-parent</artifactId>
         <version>0.2-SNAPSHOT</version>
     </parent>
-    
+
     <artifactId>boost-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
 
@@ -30,7 +31,12 @@
             <groupId>io.openliberty.boost</groupId>
             <artifactId>boost-common</artifactId>
             <version>0.2-SNAPSHOT</version>
-        </dependency>    
+        </dependency>
+        <dependency>
+            <groupId>net.wasdev.wlp.maven.plugins</groupId>
+            <artifactId>liberty-maven-plugin</artifactId>
+            <version>2.6.1-SNAPSHOT</version>
+        </dependency>
 
         <!-- Other dependencies -->
 
@@ -54,7 +60,7 @@
             <groupId>org.twdata.maven</groupId>
             <artifactId>mojo-executor</artifactId>
             <version>2.3.0</version>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
@@ -67,25 +73,25 @@
         </dependency>
 
         <dependency>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>plugin-support</artifactId>
-                <version>1.0-alpha-1</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.maven</groupId>
-                        <artifactId>maven-project</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.maven</groupId>
-                        <artifactId>maven-artifact</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.maven</groupId>
-                        <artifactId>maven-plugin-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
- 
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>plugin-support</artifactId>
+            <version>1.0-alpha-1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-project</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-artifact</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-plugin-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
     </dependencies>
 
     <profiles>
@@ -120,7 +126,7 @@
             </build>
         </profile>
     </profiles>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -135,7 +141,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>    
+            </plugin>
         </plugins>
     </build>
 

--- a/boost-maven-plugin/src/it/test-spring-boot-1.5-implicit/pom.xml
+++ b/boost-maven-plugin/src/it/test-spring-boot-1.5-implicit/pom.xml
@@ -83,6 +83,17 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<!-- Test support for classifier configuration parameter -->
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+						<configuration>
+							<classifier>exec</classifier>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-failsafe-plugin</artifactId>

--- a/boost-maven-plugin/src/it/test-spring-boot-2.0-implicit/pom.xml
+++ b/boost-maven-plugin/src/it/test-spring-boot-2.0-implicit/pom.xml
@@ -97,7 +97,9 @@
                 <executions>
                     <execution>
                         <goals>
+                            <!-- Test packaging before docker-build to validate usage of correct artifact -->
                             <goal>package</goal>
+                            <goal>docker-build</goal>
                         </goals>
                     </execution>
                     <execution>

--- a/boost-maven-plugin/src/main/java/io/openliberty/boost/docker/AbstractDockerMojo.java
+++ b/boost-maven-plugin/src/main/java/io/openliberty/boost/docker/AbstractDockerMojo.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package io.openliberty.boost.docker;
 
-import java.io.File;
-
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -32,41 +30,15 @@ import com.spotify.docker.client.auth.RegistryAuthSupplier;
 import com.spotify.docker.client.exceptions.DockerCertificateException;
 
 public abstract class AbstractDockerMojo extends AbstractMojo {
+    
     @Parameter(defaultValue = "${project}", required = true, readonly = true)
     protected MavenProject project;
 
     @Parameter(defaultValue = "${session}", readonly = true)
     protected MavenSession session;
 
-    /**
-     * The settings decrypter.
-     */
     @Component
     private SettingsDecrypter settingsDecrypter;
-
-    /**
-     * Directory containing the generated archive.
-     * 
-     * @since 1.0
-     */
-    @Parameter(defaultValue = "${project.basedir}", required = true, readonly = true)
-    protected File projectDirectory;
-
-    /**
-     * Directory containing the generated archive.
-     * 
-     * @since 1.0
-     */
-    @Parameter(defaultValue = "${project.build.directory}", required = true, readonly = true)
-    protected File outputDirectory;
-
-    /**
-     * Name of the generated archive.
-     * 
-     * @since 1.0
-     */
-    @Parameter(defaultValue = "${project.build.finalName}", required = true, readonly = true)
-    protected String finalName;
 
     /**
      * Classifier to add to the artifact generated. If given, the classifier will be
@@ -136,18 +108,6 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
             supplier = new ConfigFileRegistryAuthSupplier();
         } 
         return supplier;
-    }
-
-    protected File getAppArchive() {
-        String classifier = (this.classifier == null ? "" : this.classifier.trim());
-        if (!classifier.isEmpty() && !classifier.startsWith("-")) {
-            classifier = "-" + classifier;
-        }
-        if (!this.outputDirectory.exists()) {
-            this.outputDirectory.mkdirs();
-        }
-        return new File(this.outputDirectory,
-                this.finalName + classifier + "." + this.project.getArtifact().getArtifactHandler().getExtension());
     }
 
     protected final String getImageName() {

--- a/boost-maven-plugin/src/main/java/io/openliberty/boost/docker/DockerBuildMojo.java
+++ b/boost-maven-plugin/src/main/java/io/openliberty/boost/docker/DockerBuildMojo.java
@@ -91,8 +91,7 @@ public class DockerBuildMojo extends AbstractDockerMojo {
         // process.
         appArchive = new File(io.openliberty.boost.utils.SpringBootUtil
                 .getBoostedSpringBootUberJarPath(project.getArtifact().getFile()));
-        if (appArchive != null && appArchive.exists() && appArchive.isFile()
-                && net.wasdev.wlp.common.plugins.util.SpringBootUtil.isSpringBootUberJar(appArchive)) {
+        if (net.wasdev.wlp.common.plugins.util.SpringBootUtil.isSpringBootUberJar(appArchive)) {
             getLog().info("Found Spring Boot Uber JAR with .spring extension.");
             return appArchive;
         }

--- a/boost-maven-plugin/src/main/java/io/openliberty/boost/liberty/AbstractLibertyMojo.java
+++ b/boost-maven-plugin/src/main/java/io/openliberty/boost/liberty/AbstractLibertyMojo.java
@@ -31,16 +31,13 @@ import org.twdata.maven.mojoexecutor.MojoExecutor.Element;
 import org.twdata.maven.mojoexecutor.MojoExecutor.ExecutionEnvironment;
 
 public abstract class AbstractLibertyMojo extends MojoSupport {
-    
+
     protected String libertyServerName = "BoostServer";
 
     protected String libertyMavenPluginGroupId = "net.wasdev.wlp.maven.plugins";
     protected String libertyMavenPluginArtifactId = "liberty-maven-plugin";
-
-    /**
-     * Version of the Liberty-Maven-Plugin used by Boost
-     */
-    @Parameter(defaultValue = "2.6", readonly = true)
+    
+    @Parameter(defaultValue = "2.6.1-SNAPSHOT", readonly = true)
     protected String libertyMavenPluginVersion;
 
     @Parameter(defaultValue = "${project.build.directory}", readonly = true)
@@ -62,7 +59,7 @@ public abstract class AbstractLibertyMojo extends MojoSupport {
         return plugin(groupId(libertyMavenPluginGroupId), artifactId(libertyMavenPluginArtifactId),
                 version(libertyMavenPluginVersion));
     }
-    
+
     protected Element getRuntimeArtifactElement() {
         return element(name("assemblyArtifact"), element(name("groupId"), runtimeArtifact.getGroupId()),
                 element(name("artifactId"), runtimeArtifact.getArtifactId()),
@@ -73,5 +70,5 @@ public abstract class AbstractLibertyMojo extends MojoSupport {
     protected ExecutionEnvironment getExecutionEnvironment() {
         return executionEnvironment(project, session, pluginManager);
     }
-    
+
 }

--- a/boost-maven-plugin/src/main/java/io/openliberty/boost/liberty/LibertyDebugMojo.java
+++ b/boost-maven-plugin/src/main/java/io/openliberty/boost/liberty/LibertyDebugMojo.java
@@ -35,7 +35,7 @@ public class LibertyDebugMojo extends AbstractLibertyMojo {
     protected boolean clean;
     
     @Override
-    public void execute() throws MojoExecutionException {
+    public void execute() throws MojoExecutionException {        
         executeMojo(getPlugin(), goal("debug"),
                 configuration(
                         element(name("serverName"), libertyServerName),

--- a/boost-maven-plugin/src/main/java/io/openliberty/boost/liberty/LibertyPackageMojo.java
+++ b/boost-maven-plugin/src/main/java/io/openliberty/boost/liberty/LibertyPackageMojo.java
@@ -91,7 +91,7 @@ public class LibertyPackageMojo extends AbstractLibertyMojo {
         if (springBootVersion != null) {
             // Add the manifest to prevent Spring Boot from repackaging again
             try {
-                SpringBootUtil.addSpringBootVersionToManifest(project.getArtifact().getFile(), springBootVersion);
+                SpringBootUtil.addSpringBootVersionToManifest(project.getArtifact().getFile(), springBootVersion, BoostLogger.getInstance());
             } catch (BoostException e) {
                 throw new MojoExecutionException(e.getMessage(), e);
             }
@@ -106,7 +106,7 @@ public class LibertyPackageMojo extends AbstractLibertyMojo {
      * @throws MojoExecutionException
      */
     private void validateSpringBootUberJAR() throws MojoExecutionException {
-        if (!BoostUtil.isLibertyJar(project.getArtifact().getFile())
+        if (!BoostUtil.isLibertyJar(project.getArtifact().getFile(), BoostLogger.getInstance())
                 && !net.wasdev.wlp.common.plugins.util.SpringBootUtil.isSpringBootUberJar(
                         net.wasdev.wlp.maven.plugins.utils.SpringBootUtil.getSpringBootUberJAR(project, getLog()))) {
             throw new MojoExecutionException(
@@ -123,7 +123,7 @@ public class LibertyPackageMojo extends AbstractLibertyMojo {
      */
     private void copySpringBootUberJar() throws MojoExecutionException {
         try {
-            if (!SpringBootUtil.copySpringBootUberJar(project.getArtifact().getFile())) {
+            if (!SpringBootUtil.copySpringBootUberJar(project.getArtifact().getFile(), BoostLogger.getInstance())) {
                 File springJar = new File(
                         SpringBootUtil.getBoostedSpringBootUberJarPath(project.getArtifact().getFile()));
                 if (springJar.exists() && springJar.isFile()

--- a/boost-maven-plugin/src/main/java/io/openliberty/boost/liberty/LibertyPackageMojo.java
+++ b/boost-maven-plugin/src/main/java/io/openliberty/boost/liberty/LibertyPackageMojo.java
@@ -124,10 +124,8 @@ public class LibertyPackageMojo extends AbstractLibertyMojo {
     private void copySpringBootUberJar() throws MojoExecutionException {
         try {
             if (!SpringBootUtil.copySpringBootUberJar(project.getArtifact().getFile(), BoostLogger.getInstance())) {
-                File springJar = new File(
-                        SpringBootUtil.getBoostedSpringBootUberJarPath(project.getArtifact().getFile()));
-                if (springJar.exists() && springJar.isFile()
-                        && net.wasdev.wlp.common.plugins.util.SpringBootUtil.isSpringBootUberJar(springJar)) {
+                File springJar = new File(SpringBootUtil.getBoostedSpringBootUberJarPath(project.getArtifact().getFile()));
+                if (net.wasdev.wlp.common.plugins.util.SpringBootUtil.isSpringBootUberJar(springJar)) {
                     getLog().debug("Copying back Spring Boot Uber JAR as project artifact.");
                     FileUtils.copyFile(springJar, project.getArtifact().getFile());
                 }

--- a/boost-maven-plugin/src/main/java/io/openliberty/boost/liberty/LibertyPackageMojo.java
+++ b/boost-maven-plugin/src/main/java/io/openliberty/boost/liberty/LibertyPackageMojo.java
@@ -35,9 +35,11 @@ import io.openliberty.boost.BoostException;
 import io.openliberty.boost.BoosterPackConfigurator;
 import io.openliberty.boost.BoosterPacksParent;
 import io.openliberty.boost.utils.BoostLogger;
+import io.openliberty.boost.utils.BoostUtil;
 import io.openliberty.boost.utils.LibertyServerConfigGenerator;
 import io.openliberty.boost.utils.MavenProjectUtil;
 import io.openliberty.boost.utils.SpringBootUtil;
+import net.wasdev.wlp.common.plugins.util.PluginExecutionException;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
@@ -51,7 +53,7 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 public class LibertyPackageMojo extends AbstractLibertyMojo {
 
     String springBootVersion = null;
-    
+
     BoosterPacksParent boosterParent;
     List<BoosterPackConfigurator> boosterFeatures = null;
 
@@ -66,13 +68,14 @@ public class LibertyPackageMojo extends AbstractLibertyMojo {
 
         try {
             if (springBootVersion != null && !springBootVersion.isEmpty()) {
-                // dealing with a spring boot app
+                // Dealing with a spring boot app
+                validateSpringBootUberJAR();
                 copySpringBootUberJar();
                 installApp("spring-boot-project");
                 generateServerXML();
                 generateBootstrapProps();
             } else {
-                // dealing with an EE based app
+                // Dealing with an EE based app
                 installApp("project");
                 boosterFeatures = getBoosterConfigsFromDependencies(project);
                 generateServerXMLJ2EE(boosterFeatures);
@@ -96,6 +99,23 @@ public class LibertyPackageMojo extends AbstractLibertyMojo {
     }
 
     /**
+     * Check that we either have a Liberty Uber JAR (in which case this is a
+     * re-execution) or a Spring Boot Uber JAR (from which we will create a Liberty
+     * Uber JAR) when we begin the packaging for Spring Boot projects.
+     * 
+     * @throws MojoExecutionException
+     */
+    private void validateSpringBootUberJAR() throws MojoExecutionException {
+        if (!BoostUtil.isLibertyJar(project.getArtifact().getFile())
+                && !net.wasdev.wlp.common.plugins.util.SpringBootUtil.isSpringBootUberJar(
+                        net.wasdev.wlp.maven.plugins.utils.SpringBootUtil.getSpringBootUberJAR(project, getLog()))) {
+            throw new MojoExecutionException(
+                    "The project artifact is not a Spring Boot Uber JAR. Run spring-boot:repackage and try again.");
+        }
+
+    }
+
+    /**
      * Copy the Spring Boot uber JAR back as the project artifact, only if Spring
      * Boot didn't create it already
      * 
@@ -104,13 +124,15 @@ public class LibertyPackageMojo extends AbstractLibertyMojo {
     private void copySpringBootUberJar() throws MojoExecutionException {
         try {
             if (!SpringBootUtil.copySpringBootUberJar(project.getArtifact().getFile())) {
-                File springJar = new File(SpringBootUtil.getSpringBootUberJarPath(project.getArtifact().getFile()));
-                if (springJar.exists() && springJar.isFile()) {
+                File springJar = new File(
+                        SpringBootUtil.getBoostedSpringBootUberJarPath(project.getArtifact().getFile()));
+                if (springJar.exists() && springJar.isFile()
+                        && net.wasdev.wlp.common.plugins.util.SpringBootUtil.isSpringBootUberJar(springJar)) {
                     getLog().debug("Copying back Spring Boot Uber JAR as project artifact.");
                     FileUtils.copyFile(springJar, project.getArtifact().getFile());
                 }
             }
-        } catch (BoostException | IOException e) {
+        } catch (PluginExecutionException | IOException e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }
     }
@@ -172,7 +194,8 @@ public class LibertyPackageMojo extends AbstractLibertyMojo {
         LibertyServerConfigGenerator serverConfig = new LibertyServerConfigGenerator();
 
         // Find and add appropriate springBoot features
-        List<String> featuresNeededForSpringBootApp = SpringBootUtil.getLibertyFeaturesForSpringBoot(springBootVersion, getSpringBootStarters(), BoostLogger.getInstance());
+        List<String> featuresNeededForSpringBootApp = SpringBootUtil.getLibertyFeaturesForSpringBoot(springBootVersion,
+                getSpringBootStarters(), BoostLogger.getInstance());
         serverConfig.addFeatures(featuresNeededForSpringBootApp);
 
         serverConfig.addHttpEndpoint(null, "${server.port}", null);
@@ -276,11 +299,11 @@ public class LibertyPackageMojo extends AbstractLibertyMojo {
                         element(name("attach"), "true"), element(name("serverName"), libertyServerName)),
                 getExecutionEnvironment());
     }
-    
+
     /**
-     * Get all dependencies with "spring-boot-starter-*" as the artifactId.
-     * These dependencies will be used to determine which additional Liberty
-     * features need to be enabled.
+     * Get all dependencies with "spring-boot-starter-*" as the artifactId. These
+     * dependencies will be used to determine which additional Liberty features need
+     * to be enabled.
      * 
      */
     private List<String> getSpringBootStarters() {


### PR DESCRIPTION
This PR fixes two bugs:

1. When executing `boost:docker-build` after `boost:package`, the Docker build will fail because it will look for the Spring Boot Uber JAR based on the project artifact. However, after `boost:package` the project artifact has changed to the Liberty Uber JAR. To resolve this, logic is added to check the `.spring` file created by `boost:package` if we do not find the Spring Boot Uber JAR as the project artifact.

2. The `spring-boot-maven-plugin`'s `classifier` configuration parameter was not being accounted for properly. The parameter was not being accessed correctly so it was effectively ignored, leading to broken builds when the parameter was set. We now use the `MavenProjectUtil` from the `liberty-maven-plugin` to read the configuration and account for it properly. 

Note: this PR depends on https://github.com/WASdev/ci.maven/pull/383 and https://github.com/OpenLiberty/boost-common/pull/12. 