### PR TITLE
Add tests for server run

### DIFF
--- a/boost-maven-plugin/src/it/pom.xml
+++ b/boost-maven-plugin/src/it/pom.xml
@@ -21,6 +21,7 @@
         <module>test20Implicit</module>
         <module>testWebsocket</module>
         <module>test-docker</module>
+        <module>test-run-server</module>
     </modules>
     
 </project>

--- a/boost-maven-plugin/src/it/test-run-server/invoker.properties
+++ b/boost-maven-plugin/src/it/test-run-server/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals.1 = clean install
+# purposely avoid clean second time
+invoker.goals.2 = verify

--- a/boost-maven-plugin/src/it/test-run-server/pom.xml
+++ b/boost-maven-plugin/src/it/test-run-server/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>io.openliberty.boost</groupId>
+	<artifactId>test-run-server</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<pluginRepositories>
+		<!-- Configure Sonatype OSS Maven snapshots repository -->
+		<pluginRepository>
+			<id>sonatype-nexus-snapshots</id>
+			<name>Sonatype Nexus Snapshots</name>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</pluginRepository>
+	</pluginRepositories>
+
+	<!-- Define dependency version information -->
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>junit</groupId>
+				<artifactId>junit</artifactId>
+				<version>4.9</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-httpclient</groupId>
+				<artifactId>commons-httpclient</artifactId>
+				<version>3.1</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<version>1.5.14.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+			<version>1.5.14.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<version>1.5.14.RELEASE</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-httpclient</groupId>
+			<artifactId>commons-httpclient</artifactId>
+			<version>3.1</version>
+		</dependency>
+	</dependencies>
+
+	<properties>
+		<java.version>1.8</java.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>1.5.14.RELEASE</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.22.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>io.openliberty.boost</groupId>
+				<artifactId>boost-maven-plugin</artifactId>
+				<version>@pom.version@</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>package</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/boost-maven-plugin/src/it/test-run-server/src/main/java/hello/Application.java
+++ b/boost-maven-plugin/src/it/test-run-server/src/main/java/hello/Application.java
@@ -1,0 +1,33 @@
+package hello;
+
+import java.util.Arrays;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    public CommandLineRunner commandLineRunner(ApplicationContext ctx) {
+        return args -> {
+
+            System.out.println("Let's inspect the beans provided by Spring Boot:");
+
+            String[] beanNames = ctx.getBeanDefinitionNames();
+            Arrays.sort(beanNames);
+            for (String beanName : beanNames) {
+                System.out.println(beanName);
+            }
+
+        };
+    }
+
+}

--- a/boost-maven-plugin/src/it/test-run-server/src/main/java/hello/HelloController.java
+++ b/boost-maven-plugin/src/it/test-run-server/src/main/java/hello/HelloController.java
@@ -1,0 +1,14 @@
+package hello;
+
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RestController
+public class HelloController {
+    
+    @RequestMapping("/")
+    public String index() {
+        return "Greetings from Spring Boot!";
+    }
+    
+}

--- a/boost-maven-plugin/src/it/test-run-server/src/test/java/it/LibertyRunMojoIT.java
+++ b/boost-maven-plugin/src/it/test-run-server/src/test/java/it/LibertyRunMojoIT.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package it;
+
+import static org.junit.Assert.*;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.methods.GetMethod;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class LibertyRunMojoIT {
+    private static String URL;
+    
+    private static Process process;
+    
+    @BeforeClass 
+    public static void init() throws Exception {
+        URL = "http://localhost:8080/";
+        
+        process = Runtime.getRuntime().exec("mvn boost:run");
+    }
+    
+    @AfterClass
+    public static void teardown() throws Exception {
+        Runtime.getRuntime().exec("mvn boost:stop");
+        process.destroyForcibly();
+    }
+    
+    @Test
+    public void testLibertyRunMojo() throws Exception {
+        
+        // Verify server started message in logs
+        int timeout = 0;
+        boolean serverStarted = false;
+        
+        while(timeout < 10 && !serverStarted) {
+            
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                // Check for startup message
+                if (line.contains("CWWKF0011I")) {
+                    serverStarted = true;
+                    break;
+                }
+            }
+            
+            bufferedReader.close();
+            
+            if (!serverStarted) {
+                
+                Thread.sleep(1000);
+                timeout++;
+            }
+            
+        }
+        
+        assertTrue("The messages.log did not show that the server has started.", serverStarted);
+        
+        // Verify that the application is reachable
+        HttpClient client = new HttpClient();
+        
+        GetMethod method = new GetMethod(URL);
+        
+        try {
+            int statusCode = client.executeMethod(method);
+            
+            assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
+            
+            String response = method.getResponseBodyAsString(1000);
+            
+            assertTrue("Unexpected response body", response.contains("Greetings from Spring Boot!"));
+        } finally {
+            method.releaseConnection();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #76 "run" scenario.

The "start" and "stop" scenarios are implicitly tested when each integration test calls start/stop before and after the tests are run. Any failures in those goals would be caught there. 

The "run" goal is tested by calling `mvn boost:run` on a separate thread in the tests "BeforeClass" method. This is instead of calling "start" and "stop" before and after the integration test phase. The test then checks that the application is reachable. 