### PR TITLE
Validate <repository> and <tag> parameters

### DIFF
--- a/boost-maven-plugin/pom.xml
+++ b/boost-maven-plugin/pom.xml
@@ -91,7 +91,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
     </dependencies>
 
     <profiles>
@@ -145,6 +144,11 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>

--- a/boost-maven-plugin/src/main/java/io/openliberty/boost/docker/DockerPushMojo.java
+++ b/boost-maven-plugin/src/main/java/io/openliberty/boost/docker/DockerPushMojo.java
@@ -49,8 +49,11 @@ public class DockerPushMojo extends AbstractDockerMojo {
             Scanner in = new Scanner(System.in);
             String newRepository = in.next();
             if (newRepository == null) {
-                throw new NullPointerException("Repository name cannot be null");
+                throw new MojoExecutionException("The repository name cannot be null");
             }
+            if (!isRepositoryValid(newRepository)){
+                throw new MojoExecutionException("The repository name is invalid.");         
+            } 
             newImage = getImageName(newRepository, tag);
         }
 

--- a/boost-maven-plugin/src/main/java/io/openliberty/boost/docker/DockerPushMojo.java
+++ b/boost-maven-plugin/src/main/java/io/openliberty/boost/docker/DockerPushMojo.java
@@ -52,7 +52,7 @@ public class DockerPushMojo extends AbstractDockerMojo {
                 throw new MojoExecutionException("The repository name cannot be null");
             }
             if (!isRepositoryValid(newRepository)){
-                throw new MojoExecutionException("The repository name is invalid.");         
+                throw new MojoExecutionException("The repository name is not valid.");         
             } 
             newImage = getImageName(newRepository, tag);
         }

--- a/boost-maven-plugin/src/test/java/io/openliberty/boost/docker/DockerRepositoryTests.java
+++ b/boost-maven-plugin/src/test/java/io/openliberty/boost/docker/DockerRepositoryTests.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.boost.docker;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+public class DockerRepositoryTests {
+    
+    @Test
+    public void testValidRepositoryNames() throws Exception {
+       List<String> repositories = Arrays.asList("image", "username/image", "host.com/image", "host.com:8080/namespace/image", "host.domain.com/image",
+                "host-name.com/image", "Host.com/image","xn--wkd-8cdx9d7hbd.org/image", "user__name/image__name", "host---name.com/image---name",
+                "host.com:8080/namespace__name/image.module-name","user-name/image-name");
+        
+        for ( String repository : repositories) {
+            assertEquals(repository + " should be valid", true, AbstractDockerMojo.isRepositoryValid(repository));
+        }
+    }
+    
+    @Test
+    public void testInvalidRepositoryNames() throws Exception {
+        List<String> repositories = Arrays.asList("Image", "host_name.com:8080/image", "host__name.com:8080/image", "host.com/namepsace-/image", 
+                "host__name:8080/image", "host..com:8080/image", "host$name.com/image", "user**name/image", "image:8080", "host.com:abcd/image", 
+                "-host.com/-image", "user/repo/image/");
+        
+        for ( String repository : repositories) {
+            assertEquals(repository + " should be invalid", false, AbstractDockerMojo.isRepositoryValid(repository));
+        }
+    }
+
+}


### PR DESCRIPTION
Throw an error with a proper error message if these parameters are not set with valid names.